### PR TITLE
update nuget shared package

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/gitguardian/ggshield
+    rev: v1.13.3
+    hooks:
+      - id: ggshield
+        language_version: python3
+        stages: [commit]

--- a/ActivityHistoryApi/ActivityHistoryApi.csproj
+++ b/ActivityHistoryApi/ActivityHistoryApi.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Hackney.Core.Logging" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.56.0" />
-    <PackageReference Include="Hackney.Shared.ActivityHistory" Version="0.16.0" />
+    <PackageReference Include="Hackney.Shared.ActivityHistory" Version="0.17.0" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.1.1" />


### PR DESCRIPTION
The Activity shared Nuget package needs to be updated so it accepts type 'end' which is currently used when a Cautionary alert is ended. 