### PR TITLE
Bump JWT core to 1.87.0 for Cognito token support

### DIFF
--- a/ActivityHistoryApi/ActivityHistoryApi.csproj
+++ b/ActivityHistoryApi/ActivityHistoryApi.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.2.3" />
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
     <PackageReference Include="Hackney.Core.HealthCheck" Version="1.49.0" />
-    <PackageReference Include="Hackney.Core.JWT" Version="1.49.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.87.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.56.0" />


### PR DESCRIPTION
# What:
 - Update the `Hackney.Core.JWT` package multiple versions up _(1.49 -> ... -> 1.87)_.

# Why:
 - To get the latest version of the `ITokenFactory` implementation that adds support for the Cognito token schema.

# Notes:
 - The versions in between have no consequence. The only thing that changed about Token schema is Nbf, Exp, and Iat field types being changed from int to long.
 - What changes does latest _(v1.87.0)_ JWT intoduce? See PR: https://github.com/LBHackney-IT/lbh-core/pull/68.